### PR TITLE
SKU is "OMS" instead of "Basic"

### DIFF
--- a/manage/Automation-Best-Practices/Templates/Workspace-AutomationAccount.json
+++ b/manage/Automation-Best-Practices/Templates/Workspace-AutomationAccount.json
@@ -42,7 +42,7 @@
         "comments": "Automation account",
         "properties": {
           "sku": {
-            "name": "OMS"
+            "name": "Basic"
           }
         }
       },


### PR DESCRIPTION
We don't support "OMS". SKU needs to be "Basic".