### PR TITLE
Fixed #55, Added extra delimiter validation, Fixed favicon link

### DIFF
--- a/ready/AzNamingTool/Set-AzureNamingConfiguration.ps1
+++ b/ready/AzNamingTool/Set-AzureNamingConfiguration.ps1
@@ -1320,7 +1320,7 @@ $Html = @'
     <meta name="keywords" content="Azure, Governance, Naming, Convention, Reference, Generator">
     <meta name="author" content="FastTrack for Azure">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/x-icon" href="https://portal.azure.com/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="https://portal.azure.com/Content/favicon.ico">
     <style>
         * {
             font-family: Arial, Helvetica, sans-serif;

--- a/ready/AzNamingTool/Set-AzureNamingConfiguration.ps1
+++ b/ready/AzNamingTool/Set-AzureNamingConfiguration.ps1
@@ -1966,7 +1966,7 @@ $Html = @'
             return output;
         }
 
-        // Validate Delimiter should be used
+        // Validate Delimiter
         function validateDelimiter(name, resource, delimiter) {
             let output = false;
 
@@ -1986,6 +1986,11 @@ $Html = @'
             // Check Invalid Characters
             let invalidChars = resource.invalidCharacters;
             if (invalidChars.includes(delimiter)) {
+                output = true;
+            }
+
+            // Remove Delimiter if generated name exceeds Maximum Length
+            if (name.length > resource.lengthMax) {
                 output = true;
             }
 

--- a/ready/AzNamingTool/data/locations.csv
+++ b/ready/AzNamingTool/data/locations.csv
@@ -25,6 +25,7 @@ Japan West,jw,Asia Pacific,AzureCloud
 Jio India West,jiw,Asia Pacific,AzureCloud
 Korea Central,kc,Asia Pacific,AzureCloud
 Korea South,ks,Asia Pacific,AzureCloud
+New Zealand North,nzn,AzureCloud
 North Central US,ncu,US,AzureCloud
 North Europe,ne2,Europe,AzureCloud
 Norway East,ne,Europe,AzureCloud


### PR DESCRIPTION
- Fixed #55 by adding the New Zealand North location to the locations.csv file.
- Added extra validation with the delimiter so the delimiter is not displayed if the name has too many characters.
- Updated the Azure favicon.ico link to match the new link in the portal. 