### PR TITLE
AzNamingTool: fix infinite render loops, register StateContainer.OnChange

### DIFF
--- a/ready/AzNamingTool/Models/StateContainer.cs
+++ b/ready/AzNamingTool/Models/StateContainer.cs
@@ -85,7 +85,6 @@
             }
         }
 
-
         public void SetNewsEnabled(bool newsenabled)
         {
             _newsenabled = newsenabled;

--- a/ready/AzNamingTool/Pages/Admin.razor
+++ b/ready/AzNamingTool/Pages/Admin.razor
@@ -206,9 +206,9 @@
                 showversionalert = true;
             }
             duplicatenamesallowed = Convert.ToBoolean(ConfigurationHelper.GetAppSetting("DuplicateNamesAllowed"));
-        }
 
-        StateHasChanged();
+            StateHasChanged();
+        }
     }
 
     private async void AdminFormAction(string action)

--- a/ready/AzNamingTool/Shared/MainLayout.razor
+++ b/ready/AzNamingTool/Shared/MainLayout.razor
@@ -71,6 +71,8 @@
 
     protected override async void OnInitialized()
     {
+        state.OnChange += StateHasChanged;
+
         ConfigurationHelper.VerifyConfiguration();
         ConfigurationHelper.VerifySecurity(state);
 
@@ -107,7 +109,6 @@
                 isdarktheme = true;
             }
             state.AppTheme = theme.ThemeStyle;
-            StateHasChanged();
         }
     }
 
@@ -125,7 +126,6 @@
     private async Task OnPasswordModalClose(bool accepted)
     {
         PasswordModalOpen = false;
-        StateHasChanged();
     }
 
     private async void MagicReset()
@@ -146,8 +146,6 @@
             toastService.ShowSuccess("The site has been reset.", "MAGIC RESET ENABLED!");
 
             OpenPasswordModal();
-
-            StateHasChanged();
         }
     }
 
@@ -166,7 +164,6 @@
         }
         await storage.SetAsync("apptheme", theme.ThemeStyle);
         state.AppTheme = theme.ThemeStyle;
-        StateHasChanged();
     }
 
     private async void Logout()

--- a/ready/AzNamingTool/Shared/NavMenu.razor
+++ b/ready/AzNamingTool/Shared/NavMenu.razor
@@ -192,17 +192,15 @@
                 connected = false;
             }
             StateHasChanged();
-
         }
         else
         {
-            if ((admin != (bool)result.Value) || (servicesData == null) || (state._reloadnav))
+            if (servicesData == null || state._reloadnav)
             {
                 servicesData = await ServicesHelper.LoadServicesData(servicesData, admin);
                 state.SetNavReload(false);
             }
         }
-        StateHasChanged();
     }
 
     private void ToggleNavMenu()


### PR DESCRIPTION
Hey there,

thanks for this nice tool, it was really helpful for finding our new naming strategy.

While using it I noticed the Docker container going to max CPU usage and noticed that there were tons of messages dispatched via the websocket. Something, something, sessionStorage.getItem("admin"), which led me to these infinite re-renders.

I also noticed the StateContainer.OnChange event handler is never actually added, so I changed that, too.

The other StateHasChanged() calls I removed were from (UI) event handlers or right after updating the state container, so I believe them to be redundant, partially because of the OnChange thing I added.

This is my first time in a proper Blazor app, I don't really know what I'm doing. But it still works without the constant re-rendering, at least as far as I can tell. I hope I didn't miss any or delete too much, please let me know if I should change anything about this PR.

Have a nice day :)

fixes #128 #140